### PR TITLE
feat: hash fn encoding argument

### DIFF
--- a/src/security/hash.util.test.ts
+++ b/src/security/hash.util.test.ts
@@ -4,10 +4,8 @@ import {
   base64ToString,
   bufferToBase64,
   md5,
-  md5AsBase64,
   md5AsBuffer,
   sha256,
-  sha256AsBase64,
   sha256AsBuffer,
   stringToBase64,
 } from './hash.util'
@@ -15,7 +13,8 @@ import {
 test('md5', () => {
   const plain = 'hello!@#123'
   expect(md5(plain)).toMatchInlineSnapshot(`"41f871086829ceb41c02d2f99e11ddd0"`)
-  expect(md5AsBase64(plain)).toMatchInlineSnapshot(`"QfhxCGgpzrQcAtL5nhHd0A=="`)
+  expect(md5(plain, 'base64')).toMatchInlineSnapshot(`"QfhxCGgpzrQcAtL5nhHd0A=="`)
+  expect(md5(plain, 'base64url')).toMatchInlineSnapshot(`"QfhxCGgpzrQcAtL5nhHd0A"`)
   expect(md5AsBuffer(plain)).toMatchInlineSnapshot(`
     {
       "data": [
@@ -46,8 +45,11 @@ test('sha256', () => {
   expect(sha256(plain)).toMatchInlineSnapshot(
     `"4e6af34bdf31ddf67ffa21c7e0fa53a1a0ddf2b2a10918c2a5f5c773deb4407d"`,
   )
-  expect(sha256AsBase64(plain)).toMatchInlineSnapshot(
+  expect(sha256(plain, 'base64')).toMatchInlineSnapshot(
     `"TmrzS98x3fZ/+iHH4PpToaDd8rKhCRjCpfXHc960QH0="`,
+  )
+  expect(sha256(plain, 'base64url')).toMatchInlineSnapshot(
+    `"TmrzS98x3fZ_-iHH4PpToaDd8rKhCRjCpfXHc960QH0"`,
   )
   expect(sha256AsBuffer(plain)).toMatchInlineSnapshot(`
     {

--- a/src/security/hash.util.ts
+++ b/src/security/hash.util.ts
@@ -1,24 +1,16 @@
 import crypto, { BinaryToTextEncoding } from 'node:crypto'
-import { Base64String } from '@naturalcycles/js-lib'
+import type { Base64String, Base64UrlString } from '@naturalcycles/js-lib'
 
-export function md5(s: string | Buffer): string {
-  return hash(s, 'md5')
-}
-
-export function md5AsBase64(s: string | Buffer): Base64String {
-  return hashAsBuffer(s, 'md5').toString('base64')
+export function md5(s: string | Buffer, outputEncoding: BinaryToTextEncoding = 'hex'): string {
+  return hash(s, 'md5', outputEncoding)
 }
 
 export function md5AsBuffer(s: string | Buffer): Buffer {
   return hashAsBuffer(s, 'md5')
 }
 
-export function sha256(s: string | Buffer): string {
-  return hash(s, 'sha256')
-}
-
-export function sha256AsBase64(s: string | Buffer): Base64String {
-  return hashAsBuffer(s, 'sha256').toString('base64')
+export function sha256(s: string | Buffer, outputEncoding: BinaryToTextEncoding = 'hex'): string {
+  return hash(s, 'sha256', outputEncoding)
 }
 
 export function sha256AsBuffer(s: string | Buffer): Buffer {
@@ -28,9 +20,9 @@ export function sha256AsBuffer(s: string | Buffer): Buffer {
 export function hash(
   s: string | Buffer,
   algorithm: string,
-  encoding: BinaryToTextEncoding = 'hex',
+  outputEncoding: BinaryToTextEncoding = 'hex',
 ): string {
-  return crypto.createHash(algorithm).update(s).digest(encoding)
+  return crypto.createHash(algorithm).update(s).digest(outputEncoding)
 }
 
 export function hashAsBuffer(s: string | Buffer, algorithm: string): Buffer {
@@ -41,18 +33,38 @@ export function base64(s: string | Buffer): Base64String {
   return (typeof s === 'string' ? Buffer.from(s) : s).toString('base64')
 }
 
+export function base64Url(s: string | Buffer): Base64UrlString {
+  return (typeof s === 'string' ? Buffer.from(s) : s).toString('base64url')
+}
+
 export function base64ToString(strBase64: Base64String): string {
   return Buffer.from(strBase64, 'base64').toString('utf8')
 }
 
-export function base64ToBuffer(strBase64: string): Buffer {
+export function base64UrlToString(strBase64Url: Base64UrlString): string {
+  return Buffer.from(strBase64Url, 'base64url').toString('utf8')
+}
+
+export function base64ToBuffer(strBase64: Base64String): Buffer {
   return Buffer.from(strBase64, 'base64')
+}
+
+export function base64UrlToBuffer(strBase64Url: Base64UrlString): Buffer {
+  return Buffer.from(strBase64Url, 'base64url')
 }
 
 export function stringToBase64(s: string): Base64String {
   return Buffer.from(s, 'utf8').toString('base64')
 }
 
+export function stringToBase64Url(s: string): Base64UrlString {
+  return Buffer.from(s, 'utf8').toString('base64url')
+}
+
 export function bufferToBase64(b: Buffer): Base64String {
   return b.toString('base64')
+}
+
+export function bufferToBase64Url(b: Buffer): Base64UrlString {
+  return b.toString('base64url')
 }

--- a/src/security/hash.util.ts
+++ b/src/security/hash.util.ts
@@ -1,4 +1,4 @@
-import crypto from 'node:crypto'
+import crypto, { BinaryToTextEncoding } from 'node:crypto'
 import { Base64String } from '@naturalcycles/js-lib'
 
 export function md5(s: string | Buffer): string {
@@ -25,8 +25,12 @@ export function sha256AsBuffer(s: string | Buffer): Buffer {
   return hashAsBuffer(s, 'sha256')
 }
 
-export function hash(s: string | Buffer, algorithm: string): string {
-  return crypto.createHash(algorithm).update(s).digest('hex')
+export function hash(
+  s: string | Buffer,
+  algorithm: string,
+  encoding: BinaryToTextEncoding = 'hex',
+): string {
+  return crypto.createHash(algorithm).update(s).digest(encoding)
 }
 
 export function hashAsBuffer(s: string | Buffer, algorithm: string): Buffer {


### PR DESCRIPTION
Adds possibility to change encoding on hash function. Inspired from this comment in NCBackend3

```
    // TODO: move the sha256 with base64url into convenience method "sha256"??
    return crypto
      .createHash('sha256')
      .update(sessionIdPepper + plain)
      .digest('base64url')
```