### PR TITLE
feat: add option to not log command

### DIFF
--- a/src/util/exec.util.ts
+++ b/src/util/exec.util.ts
@@ -1,12 +1,21 @@
 import type { ProcessEnvOptions, SpawnOptions } from 'node:child_process'
 import cp from 'node:child_process'
 
+interface ExecCommandOptions extends SpawnOptions {
+  /**
+   * Set to true to not log the command (for less verbose output)
+   */
+  hideCommand?: boolean
+}
+
 export async function execVoidCommand(
   cmd: string,
   args: string[] = [],
-  opt: SpawnOptions = {},
+  opt: ExecCommandOptions = {},
 ): Promise<void> {
-  logExec(cmd, args, opt)
+  if (!opt.hideCommand) {
+    logExec(cmd, args, opt)
+  }
 
   await new Promise<void>(resolve => {
     const p = cp.spawn(cmd, [...args], {
@@ -32,9 +41,11 @@ export async function execVoidCommand(
 export function execVoidCommandSync(
   cmd: string,
   args: string[] = [],
-  opt: SpawnOptions = {},
+  opt: ExecCommandOptions = {},
 ): void {
-  logExec(cmd, args, opt)
+  if (!opt.hideCommand) {
+    logExec(cmd, args, opt)
+  }
 
   const r = cp.spawnSync(cmd, [...args], {
     encoding: 'utf8',

--- a/src/util/exec.util.ts
+++ b/src/util/exec.util.ts
@@ -1,21 +1,20 @@
 import type { ProcessEnvOptions, SpawnOptions } from 'node:child_process'
 import cp from 'node:child_process'
 
-interface ExecCommandOptions extends SpawnOptions {
+export interface ExecOptions extends SpawnOptions {
   /**
-   * Set to true to not log the command (for less verbose output)
+   * Defaults to true.
+   * Set to false to skip logging.
    */
-  hideCommand?: boolean
+  log?: boolean
 }
 
 export async function execVoidCommand(
   cmd: string,
   args: string[] = [],
-  opt: ExecCommandOptions = {},
+  opt: ExecOptions = {},
 ): Promise<void> {
-  if (!opt.hideCommand) {
-    logExec(cmd, args, opt)
-  }
+  logExec(cmd, args, opt)
 
   await new Promise<void>(resolve => {
     const p = cp.spawn(cmd, [...args], {
@@ -38,14 +37,8 @@ export async function execVoidCommand(
   })
 }
 
-export function execVoidCommandSync(
-  cmd: string,
-  args: string[] = [],
-  opt: ExecCommandOptions = {},
-): void {
-  if (!opt.hideCommand) {
-    logExec(cmd, args, opt)
-  }
+export function execVoidCommandSync(cmd: string, args: string[] = [], opt: ExecOptions = {}): void {
+  logExec(cmd, args, opt)
 
   const r = cp.spawnSync(cmd, [...args], {
     encoding: 'utf8',
@@ -69,7 +62,13 @@ export function execVoidCommandSync(
   }
 }
 
-function logExec(cmd: string, args: string[] = [], opt: ProcessEnvOptions = {}): void {
+function logExec(
+  cmd: string,
+  args: string[] = [],
+  opt: ProcessEnvOptions & ExecOptions = {},
+): void {
+  if (opt.log === false) return
+
   const cmdline = [
     ...Object.entries(opt.env || {}).map(([k, v]) => [k, v].join('=')),
     cmd,


### PR DESCRIPTION
For the "concat files in GCS" script, I need to use the `execVoidCommand` function, and it would be nice to have it not output all of the commands, since it's very verbose.
I added an option to hide the command, and the default value (`undefined`). should leave the behaviour unchanged

`squash-on-green`